### PR TITLE
Print explaining error message if the sequence size exceeds the maximum size

### DIFF
--- a/src/CFastaFile.cpp
+++ b/src/CFastaFile.cpp
@@ -130,6 +130,10 @@ unsigned char * CFastaFile::nextSeq(int *length, int* alignedLength, int pad) {
 			fprintf(stderr, "it is impossible\n");
 			goto err;
 		}
+		if (pos >= MAX_SEQ_LENGTH) {
+			fprintf(stderr, "Sequence '%s' exceeds the size limit of %d \n", name, MAX_SEQ_LENGTH);
+			goto err;
+		}
 		//remove the newline
 		p = buf + pos;
 		for (; *p && (*p != '\r' && *p != '\n'); p++) {


### PR DESCRIPTION
I have observed segmentation fault because one of the sequences in my input file was too long. The fault was happening without any error message in the output so the reason was not obvious and could be easily attributed to a but inside the cudasw itself. I propose printing the clear error message before terminating the program. It is my own code, done on private software outside the working hours. I put the change on public domain. Audrius Meskauskas.